### PR TITLE
[improvement] add support for the JVM build target

### DIFF
--- a/build-logic/src/main/kotlin/SimpleMVILibraryModule.kt
+++ b/build-logic/src/main/kotlin/SimpleMVILibraryModule.kt
@@ -30,6 +30,7 @@ class SimpleMVILibraryModule : Plugin<Project> {
             wasmJs {
                 browser()
             }
+            jvm()
 
             explicitApi()
 

--- a/build-logic/src/main/kotlin/utils/Constant.kt
+++ b/build-logic/src/main/kotlin/utils/Constant.kt
@@ -3,4 +3,4 @@ package utils
 const val COMPILE_SDK_VERSION = 35
 const val MIN_SDK_VERSION = 24
 
-const val LIBRARY_VERSION = "0.5.0"
+const val LIBRARY_VERSION = "0.5.1"

--- a/simplemvi/src/jvmMain/kotlin/com/arttttt/simplemvi/logging/logger/Logging.jvm.kt
+++ b/simplemvi/src/jvmMain/kotlin/com/arttttt/simplemvi/logging/logger/Logging.jvm.kt
@@ -1,0 +1,12 @@
+package com.arttttt.simplemvi.logging.logger
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+private val logTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
+
+public actual fun logV(tag: String, message: String) {
+    val time = ZonedDateTime.now().format(logTimeFormatter)
+    println("$time [$tag]: $message")
+}

--- a/simplemvi/src/jvmMain/kotlin/com/arttttt/simplemvi/utils/MainThreadAssert.jvm.kt
+++ b/simplemvi/src/jvmMain/kotlin/com/arttttt/simplemvi/utils/MainThreadAssert.jvm.kt
@@ -1,0 +1,16 @@
+package com.arttttt.simplemvi.utils
+
+import javax.swing.SwingUtilities
+
+/**
+ * Use this global variable to set a custom main thread check if you use a custom UI framework.
+ */
+@Volatile
+public var isMainThreadResolver: () -> Boolean = {
+    SwingUtilities.isEventDispatchThread()
+}
+
+/**
+ * each supported platform must provide a main thread check
+ */
+public actual fun isMainThread(): Boolean = isMainThreadResolver()


### PR DESCRIPTION
Currently, there's no available package on Sonatype for the JVM target (which is typical for desktop Compose)